### PR TITLE
ESLint 에러 메시지 해결

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -3,8 +3,9 @@ module.exports = {
     "airbnb",
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
+    "plugin:prettier/recommended",
   ],
-  plugins: ["react", "react-hooks"],
+  plugins: ["react", "react-hooks", "unused-imports", "prettier"],
   env: {
     browser: true,
     es2021: true,
@@ -24,8 +25,16 @@ module.exports = {
     "react/react-in-jsx-scope": "off",
     "prefer-arrow-callback": "warn",
     "func-style": ["warn", "expression", { allowArrowFunctions: true }],
+    "react/function-component-definition": [
+      "error",
+      {
+        namedComponents: "arrow-function",
+        unnamedComponents: "arrow-function",
+      },
+    ],
     "no-console": "warn",
     "prettier/prettier": "warn",
+    quotes: [2, "double", { avoidEscape: false }],
   },
   overrides: [
     {


### PR DESCRIPTION
### 문제 상황
`eslintrc.cjs`에서 발생하는 여러 에러들을 해결했습니다. 뜬 에러는 다음과 같습니다.

**String must use singlequote.**
  - `ESLint`는 기본적으로 코드 내에서 작은따옴표(`'`)를 사용하도록 강제합니다.
  - 큰 따옴표를 사용하도록 `prettier`를 설정했지만 `eslintrc.cjs`에서는 설정해 주지 않은 것이 문제였습니다.
  
**Funtion component is not a function declaration**
  - `ESLint`에서는 컴포넌트를 정의할 때 함수 선언문을 사용하도록 권장합니다. 함수 표현식을 사용하려 하면 error를 띄우게 됩니다.
  - `eslintrc.cjs` 파일에 `func-style`에 대한 규칙은 존재하지만 `react/function-component-definition`는 존재하지 않아 발생한 문제였습니다.

**Definition for rule 'prettier/prettier' was not found.eslint**
- eslint 설정에서 unused-imports/no-unused-imports와 prettier/prettier 규칙이 정의되었지만 규칙을 찾지 못 한다는 에러 메시지였습니다.
- .eslintrc.js 파일에서 정의된 규칙에 필요한 `prettier` 플러그인이 설정에 포함되어 있지 않아서 발생한 문제였습니다.


### 해결 
**String must use singlequote 오류 해결**
  - `eslintrc.cjs`에서도 큰따옴표를 사용하도록 설정했더니 해결되었습니다.
```js
rules: {
    quotes: [2, "double", { "avoidEscape": false }],
    // ...
}
```
**Funtion component is not a function declaration 오류 해결**
  - `eslintrc.cjs`에 컴포넌트 또한 화살표 함수를 사용하도록 하는 규칙을 추가했더니 해결되었습니다.
```js
"rules": {
    "react/function-component-definition": [
      "error",
      {
        "namedComponents": "arrow-function",
        "unnamedComponents": "arrow-function"
      }
    ],
   // ...
  }
  ```
 
**Definition for rule 'prettier/prettier' was not found.eslint 오류 해결**
  - `eslintrc.cjs` 파일 안에서 extends에 "plugin:prettier/recommended"를 추가합니다. 이렇게 하면 `ESLint`와 `Prettier` 규칙이 충돌할 때 충돌을 자동으로 해결됩니다.
  - "unused-imports"와 "prettier" 플러그인을 설정해 줍니다.
  ```js
 extends: [
    "airbnb",
    "plugin:react/recommended",
    "plugin:react-hooks/recommended",
    "plugin:prettier/recommended",
  ],
 plugins: ["react", "react-hooks", "unused-imports", "prettier"],
  ```
  
  > 노션 이슈 기록 페이지를 참고해 주세요.
  > [이슈 기록](https://balsam-ceramic-da1.notion.site/1337aad7a2ea8016972ff891dea5c6b2?pvs=4)