### PR TITLE
Feature/rotate chuck by button(마우스 클릭 이벤트 감지)

### DIFF
--- a/src/components/CanvasPainter.jsx
+++ b/src/components/CanvasPainter.jsx
@@ -6,17 +6,18 @@ import { Raycaster } from "three";
 import Chuck from "./Chuck";
 import ReverseChuck from "./ReverseChuck";
 
-const SimulCanvas = ({ rotationAngle }) => {
+const CanvasPainter = ({ rotationAngle }) => {
   const raycastingRef = useRef(new Raycaster());
   const { camera, gl, scene } = useThree();
 
   const handleClickChuck = (event) => {
     event.stopPropagation();
-    const mouseClick = new THREE.Vector2(
+
+    const syncCordinater = new THREE.Vector2(
       (event.offsetX / gl.domElement.clientWidth) * 2 - 1,
       -(event.offsetY / gl.domElement.clientHeight) * 2 + 1
     );
-    raycastingRef.current.setFromCamera(mouseClick, camera);
+    raycastingRef.current.setFromCamera(syncCordinater, camera);
     raycastingRef.current.precision = 0.000001;
 
     let intersects = raycastingRef.current.intersectObjects(
@@ -45,4 +46,4 @@ const SimulCanvas = ({ rotationAngle }) => {
   );
 };
 
-export default SimulCanvas;
+export default CanvasPainter;

--- a/src/components/Chuck.jsx
+++ b/src/components/Chuck.jsx
@@ -1,8 +1,12 @@
 import { useFrame } from "@react-three/fiber";
+import { useRef } from "react";
 import * as THREE from "three";
 import * as CONSTANTS from "../constants/constants";
 
-const Chuck = ({ position, color }) => {
+const Chuck = ({ position, color, rotationAngle }) => {
+  const chuckRef = useRef();
+  const currentRotatoinAngle = useRef(0);
+  const customAxis = new THREE.Vector3(1, CONSTANTS.YVERTEX / 3, 0).normalize();
   // prettier-ignore
   const vertexArray = new Float32Array([
     0, 0, -1,
@@ -32,9 +36,22 @@ const Chuck = ({ position, color }) => {
   customGeometry.setIndex(shapeFace);
   const shapeFaceEdgeLine = new THREE.EdgesGeometry(customGeometry);
 
+  useFrame(() => {
+    if (currentRotatoinAngle !== rotationAngle) {
+      currentRotatoinAngle.current = THREE.MathUtils.lerp(
+        currentRotatoinAngle.current,
+        rotationAngle,
+        0.02
+      );
+      const customRotation = new THREE.Quaternion();
+      customRotation.setFromAxisAngle(customAxis, currentRotatoinAngle.current);
+      chuckRef.current.quaternion.copy(customRotation);
+    }
+  });
+
   return (
     <>
-      <mesh geometry={customGeometry} position={position}>
+      <mesh ref={chuckRef} geometry={customGeometry} position={position}>
         <meshBasicMaterial color={color} side={THREE.DoubleSide} />
         <lineSegments geometry={shapeFaceEdgeLine}>
           <lineBasicMaterial color="black" />

--- a/src/components/Chuck.jsx
+++ b/src/components/Chuck.jsx
@@ -45,6 +45,7 @@ const Chuck = ({ position, color, rotationAngle }) => {
         rotationAngle,
         0.02
       );
+
       const customRotation = new THREE.Quaternion();
       customRotation.setFromAxisAngle(customAxis, currentRotatoinAngle.current);
       chuckRef.current.quaternion.copy(customRotation);

--- a/src/components/Chuck.jsx
+++ b/src/components/Chuck.jsx
@@ -34,6 +34,8 @@ const Chuck = ({ position, color, rotationAngle }) => {
     new THREE.BufferAttribute(vertexArray, 3)
   );
   customGeometry.setIndex(shapeFace);
+  customGeometry.computeBoundingBox();
+  customGeometry.computeBoundingSphere();
   const shapeFaceEdgeLine = new THREE.EdgesGeometry(customGeometry);
 
   useFrame(() => {
@@ -51,7 +53,12 @@ const Chuck = ({ position, color, rotationAngle }) => {
 
   return (
     <>
-      <mesh ref={chuckRef} geometry={customGeometry} position={position}>
+      <mesh
+        ref={chuckRef}
+        geometry={customGeometry}
+        position={position}
+        userData={{ position, color }}
+      >
         <meshBasicMaterial color={color} side={THREE.DoubleSide} />
         <lineSegments geometry={shapeFaceEdgeLine}>
           <lineBasicMaterial color="black" />

--- a/src/components/ReverseChuck.jsx
+++ b/src/components/ReverseChuck.jsx
@@ -45,6 +45,7 @@ const ReverseChuck = ({ position, color, rotationAngle }) => {
         rotationAngle,
         0.02
       );
+
       const customRotation = new THREE.Quaternion();
       customRotation.setFromAxisAngle(customAxis, currentRotatoinAngle.current);
       chuckRef.current.quaternion.copy(customRotation);

--- a/src/components/ReverseChuck.jsx
+++ b/src/components/ReverseChuck.jsx
@@ -1,9 +1,12 @@
-import { useEffect, useRef } from "react";
+import { useFrame } from "@react-three/fiber";
+import { useRef } from "react";
 import * as THREE from "three";
 import * as CONSTANTS from "../constants/constants.js";
 
 const ReverseChuck = ({ position, color, rotationAngle }) => {
   const chuckRef = useRef();
+  const currentRotatoinAngle = useRef(0);
+  const customAxis = new THREE.Vector3(1, CONSTANTS.YVERTEX / 3, 0).normalize();
   // prettier-ignore
   const vertexArray = new Float32Array([
     1, CONSTANTS.YVERTEX, -1,
@@ -34,20 +37,18 @@ const ReverseChuck = ({ position, color, rotationAngle }) => {
 
   const shapeFaceEdgeLine = new THREE.EdgesGeometry(customGeometry);
 
-  useEffect(() => {
-    if (chuckRef.current) {
-      const customAxis = new THREE.Vector3(
-        1,
-        CONSTANTS.YVERTEX / 3,
-        0
-      ).normalize();
-      const customRotation = new THREE.Quaternion().setFromAxisAngle(
-        customAxis,
-        rotationAngle
+  useFrame(() => {
+    if (currentRotatoinAngle !== rotationAngle) {
+      currentRotatoinAngle.current = THREE.MathUtils.lerp(
+        currentRotatoinAngle.current,
+        rotationAngle,
+        0.02
       );
+      const customRotation = new THREE.Quaternion();
+      customRotation.setFromAxisAngle(customAxis, currentRotatoinAngle.current);
       chuckRef.current.quaternion.copy(customRotation);
     }
-  }, [rotationAngle]);
+  });
 
   return (
     <>

--- a/src/components/ReverseChuck.jsx
+++ b/src/components/ReverseChuck.jsx
@@ -1,7 +1,7 @@
 import { useFrame } from "@react-three/fiber";
 import { useRef } from "react";
 import * as THREE from "three";
-import * as CONSTANTS from "../constants/constants.js";
+import * as CONSTANTS from "../constants/constants";
 
 const ReverseChuck = ({ position, color, rotationAngle }) => {
   const chuckRef = useRef();
@@ -34,7 +34,8 @@ const ReverseChuck = ({ position, color, rotationAngle }) => {
     new THREE.BufferAttribute(vertexArray, 3)
   );
   customGeometry.setIndex(shapeFace);
-
+  customGeometry.computeBoundingBox();
+  customGeometry.computeBoundingSphere();
   const shapeFaceEdgeLine = new THREE.EdgesGeometry(customGeometry);
 
   useFrame(() => {
@@ -52,7 +53,12 @@ const ReverseChuck = ({ position, color, rotationAngle }) => {
 
   return (
     <>
-      <mesh ref={chuckRef} geometry={customGeometry} position={position}>
+      <mesh
+        ref={chuckRef}
+        geometry={customGeometry}
+        position={position}
+        userData={{ position, color }}
+      >
         <meshBasicMaterial color={color} side={THREE.DoubleSide} />
         <lineSegments geometry={shapeFaceEdgeLine}>
           <lineBasicMaterial color="black" />

--- a/src/components/SimulCanvas.jsx
+++ b/src/components/SimulCanvas.jsx
@@ -1,21 +1,54 @@
 import { OrbitControls } from "@react-three/drei";
-import { Canvas } from "@react-three/fiber";
+import { useThree } from "@react-three/fiber";
+import { useRef } from "react";
+import * as THREE from "three";
+import { Raycaster } from "three";
 import Chuck from "./Chuck";
 import ReverseChuck from "./ReverseChuck";
 
 const SimulCanvas = ({ rotationAngle }) => {
+  const raycastingRef = useRef(new Raycaster());
+  const { camera, gl, scene } = useThree();
+
+  const handleClickChuck = (event) => {
+    event.stopPropagation();
+    const mouseClick = new THREE.Vector2(
+      ((event.clientX - gl.domElement.offsetLeft) / gl.domElement.clientWidth) *
+        2 -
+        1,
+      -(
+        (event.clientY - gl.domElement.offsetTop) /
+        gl.domElement.clientHeight
+      ) *
+        2 +
+        1
+    );
+    raycastingRef.current.setFromCamera(mouseClick, camera);
+    raycastingRef.current.precision = 0.000001;
+
+    let intersects = raycastingRef.current.intersectObjects(
+      scene.children,
+      true
+    );
+    intersects = intersects.filter((intersect) => intersect.object.isMesh);
+
+    if (intersects.length > 0) {
+      const clickedObject = intersects[0].object;
+      const { position, color } = clickedObject.userData;
+    }
+  };
+
   return (
-    <Canvas
-      camera={{
-        position: [2, 5, 5],
-        fov: 100,
-      }}
-    >
+    <group onPointerDown={handleClickChuck}>
       <Chuck position={[0, 0, 0]} color="green" rotationAngle={rotationAngle} />
-      <ReverseChuck position={[0, 0, 0]} color="red" rotationAngle={rotationAngle} />
+      <ReverseChuck
+        position={[0, 0, 0]}
+        color="red"
+        rotationAngle={rotationAngle}
+      />
       <Chuck position={[2, 0, 0]} color="green" rotationAngle={rotationAngle} />
       <OrbitControls />
-    </Canvas>
+    </group>
   );
 };
 

--- a/src/components/SimulCanvas.jsx
+++ b/src/components/SimulCanvas.jsx
@@ -11,12 +11,9 @@ const SimulCanvas = ({ rotationAngle }) => {
         fov: 100,
       }}
     >
-      <Chuck position={[0, 0, 0]} color="green" />
-      <ReverseChuck
-        position={[0, 0, 0]}
-        color="red"
-        rotationAngle={rotationAngle}
-      />
+      <Chuck position={[0, 0, 0]} color="green" rotationAngle={rotationAngle} />
+      <ReverseChuck position={[0, 0, 0]} color="red" rotationAngle={rotationAngle} />
+      <Chuck position={[2, 0, 0]} color="green" rotationAngle={rotationAngle} />
       <OrbitControls />
     </Canvas>
   );

--- a/src/components/SimulCanvas.jsx
+++ b/src/components/SimulCanvas.jsx
@@ -1,22 +1,9 @@
 import { OrbitControls } from "@react-three/drei";
 import { Canvas } from "@react-three/fiber";
-import { useEffect, useState, useRef } from "react";
-import * as CONSTANTS from "../constants/constants";
 import Chuck from "./Chuck";
 import ReverseChuck from "./ReverseChuck";
 
-const SimulCanvas = () => {
-  const [rotationAngle, setRotationAngle] = useState(0);
-  const [groupRotation, setGroupRotation] = useState([]);
-  const groupRef1 = useRef();
-
-  useEffect(() => {
-    const testInterval = setInterval(() => {
-      setRotationAngle((preAngle) => preAngle + 90 * CONSTANTS.DEGREE);
-    }, 3000);
-    return () => clearInterval(testInterval);
-  }, []);
-
+const SimulCanvas = ({ rotationAngle }) => {
   return (
     <Canvas
       camera={{
@@ -30,11 +17,6 @@ const SimulCanvas = () => {
         color="red"
         rotationAngle={rotationAngle}
       />
-      <group ref={groupRef1}>
-        <Chuck position={[0, -1, -1]} color="green" />
-        <Chuck position={[2, -1, -1]} color="red" rotation={[0, 0, 1.05]} />
-        <Chuck position={[2, -1, -1]} color="green" />
-      </group>
       <OrbitControls />
     </Canvas>
   );

--- a/src/components/SimulCanvas.jsx
+++ b/src/components/SimulCanvas.jsx
@@ -13,15 +13,8 @@ const SimulCanvas = ({ rotationAngle }) => {
   const handleClickChuck = (event) => {
     event.stopPropagation();
     const mouseClick = new THREE.Vector2(
-      ((event.clientX - gl.domElement.offsetLeft) / gl.domElement.clientWidth) *
-        2 -
-        1,
-      -(
-        (event.clientY - gl.domElement.offsetTop) /
-        gl.domElement.clientHeight
-      ) *
-        2 +
-        1
+      (event.offsetX / gl.domElement.clientWidth) * 2 - 1,
+      -(event.offsetY / gl.domElement.clientHeight) * 2 + 1
     );
     raycastingRef.current.setFromCamera(mouseClick, camera);
     raycastingRef.current.precision = 0.000001;

--- a/src/components/SimulController.jsx
+++ b/src/components/SimulController.jsx
@@ -7,7 +7,6 @@ import Button from "./Button";
 const SimulController = ({ setRotationAngle }) => {
   const chuckLength = useChuckStore((state) => state.chuckLength);
   const [isOpenedReset, setIsOpenedReset] = useState(false);
-  const [clickState, setClickState] = useState([false, false]);
 
   const handleClickReset = () => {
     setIsOpenedReset(true);

--- a/src/components/SimulController.jsx
+++ b/src/components/SimulController.jsx
@@ -7,6 +7,7 @@ import Button from "./Button";
 const SimulController = ({ setRotationAngle }) => {
   const chuckLength = useChuckStore((state) => state.chuckLength);
   const [isOpenedReset, setIsOpenedReset] = useState(false);
+  const [clickState, setClickState] = useState([false, false]);
 
   const handleClickReset = () => {
     setIsOpenedReset(true);

--- a/src/components/SimulController.jsx
+++ b/src/components/SimulController.jsx
@@ -1,14 +1,21 @@
 import { useState } from "react";
+import * as CONSTANTS from "../constants/constants";
 import ResetModal from "../pages/Modal/ResetModal";
 import useChuckStore from "../store/chuckStore";
 import Button from "./Button";
 
-const SimulController = () => {
+const SimulController = ({ setRotationAngle }) => {
   const chuckLength = useChuckStore((state) => state.chuckLength);
   const [isOpenedReset, setIsOpenedReset] = useState(false);
 
   const handleClickReset = () => {
     setIsOpenedReset(true);
+  };
+  const handleClickLeft = () => {
+    setRotationAngle((prevAngle) => prevAngle - 90 * CONSTANTS.DEGREE);
+  };
+  const handleClickRight = () => {
+    setRotationAngle((prevAngle) => prevAngle + 90 * CONSTANTS.DEGREE);
   };
 
   return (
@@ -16,8 +23,12 @@ const SimulController = () => {
       <div className="flex flex-col gap-3 fixed bottom-2 right-2 w-[250px] h-[250px] bg-slate-600 p-3 justify-center items-center">
         <div className="w-[90%] flex gap-2 items-center">
           <p className="grow text-center font-bold text-lg">Turn!</p>
-          <Button addClassName="h-10 p-1">Left</Button>
-          <Button addClassName="h-10 p-1">Right</Button>
+          <Button addClassName="h-10 p-1" handler={handleClickLeft}>
+            Left
+          </Button>
+          <Button addClassName="h-10 p-1" handler={handleClickRight}>
+            Right
+          </Button>
         </div>
         <div className="w-[80%] flex gap-3 items-center">
           <div className="grow font-bold text-lg">length?</div>

--- a/src/pages/Simulator.jsx
+++ b/src/pages/Simulator.jsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import Header from "../components/Header";
 import SimulCanvas from "../components/SimulCanvas";
 import SimulController from "../components/SimulController";
@@ -6,14 +7,15 @@ import InitialSettingModal from "./Modal/InitialSettingModal";
 
 const Simulator = () => {
   const isOpenedInitial = usePageStore((state) => state.isOpenedModal);
+  const [rotationAngle, setRotationAngle] = useState(0);
 
   return (
     <div className="text-white">
       {isOpenedInitial && <InitialSettingModal />}
       <Header />
       <main className="w-[90%] h-[100vh]">
-        <SimulCanvas />
-        <SimulController />
+        <SimulCanvas rotationAngle={rotationAngle} />
+        <SimulController setRotationAngle={setRotationAngle} />
       </main>
     </div>
   );

--- a/src/pages/Simulator.jsx
+++ b/src/pages/Simulator.jsx
@@ -1,3 +1,4 @@
+import { Canvas } from "@react-three/fiber";
 import { useState } from "react";
 import Header from "../components/Header";
 import SimulCanvas from "../components/SimulCanvas";
@@ -14,7 +15,14 @@ const Simulator = () => {
       {isOpenedInitial && <InitialSettingModal />}
       <Header />
       <main className="w-[90%] h-[100vh]">
-        <SimulCanvas rotationAngle={rotationAngle} />
+        <Canvas
+          camera={{
+            position: [2, 5, 5],
+            fov: 100,
+          }}
+        >
+          <SimulCanvas rotationAngle={rotationAngle} />
+        </Canvas>
         <SimulController setRotationAngle={setRotationAngle} />
       </main>
     </div>

--- a/src/pages/Simulator.jsx
+++ b/src/pages/Simulator.jsx
@@ -1,7 +1,7 @@
 import { Canvas } from "@react-three/fiber";
 import { useState } from "react";
 import Header from "../components/Header";
-import SimulCanvas from "../components/SimulCanvas";
+import CanvasPainter from "../components/CanvasPainter";
 import SimulController from "../components/SimulController";
 import usePageStore from "../store/pageStore";
 import InitialSettingModal from "./Modal/InitialSettingModal";
@@ -21,7 +21,7 @@ const Simulator = () => {
             fov: 100,
           }}
         >
-          <SimulCanvas rotationAngle={rotationAngle} />
+          <CanvasPainter rotationAngle={rotationAngle} />
         </Canvas>
         <SimulController setRotationAngle={setRotationAngle} />
       </main>


### PR DESCRIPTION
# 작업 내용

- [x]  사용자가 마우스 클릭으로 기준 삼각 기둥을 선택 할 수 있어야한다
- [x] 클릭시 해당 기둥의 포지션 및 색상 정보를 받아와야한다 


## 목업 UI 화면

<img width="593" alt="스크린샷 2024-11-07 14 01 28" src="https://github.com/user-attachments/assets/f27128a4-2df2-45eb-9b45-c1a58ffdd810">

## 실제 구현 화면

<img width="1470" alt="스크린샷 2024-11-07 13 29 48" src="https://github.com/user-attachments/assets/8541aea4-148b-45a4-9cb6-4a85e9d3ba87">


# 참고 사항

1. 해당 태스크에 마우스 클릭이 일어난 기둥 기준 좌, 우를 기둥을 선택 가능하게 하고 회전 방향도 지정하는 세부 태스크가 존재하지만, 마우스 클릭 구현에 너무 많은 시간이 걸려서 해당 기능을 우선적으로 PR 올렸습니다.

2. Canvas 컴포넌트의 위치를 기존 simulatorCanvas 컴포넌트의 부모인 simulator로 이동 시켰습니다. 기능이 추가됨에 따라서 react-three-fiber hook의 사용 로직이 많아지고 있고, 이에 따라 기존 Canvas의 위치가 유지된다면 chuck 과 Reversechuck 컴포넌트의 로직이 복잡해 질 것이라 예상되어 이번 마우스 이벤트 태스크 진행간 변경하였습니다.

# 리뷰 반영 내용

리뷰 내용 반영 후 수정 내용 발생시 이 부분에 작성해 주세요.
