### PR TITLE
Remove/initial setting UI: 척척이 길이 초기 셋팅 기능 삭제

### DIFF
--- a/src/components/SimulController.jsx
+++ b/src/components/SimulController.jsx
@@ -58,9 +58,11 @@ const SimulController = ({ clickedChuckInfo, setRotationAngle }) => {
 
   return (
     <>
-      <div className="flex flex-col gap-3 fixed bottom-2 right-2 w-[250px] h-[250px] bg-slate-600 p-3 justify-center items-center">
+      <div className="flex flex-col gap-4 fixed bottom-2 right-2 w-[230px] h-[230px] bg-slate-600 p-3 justify-center items-center">
         <div className="w-[90%] flex gap-2 items-center">
-          <p className="grow text-center font-bold text-lg">Turn!</p>
+          <p className="pl-[20px] pr-[30px] text-center font-bold text-xl">
+            Turn!
+          </p>
           <Button className="h-10 p-1" clickHandler={handleClickLeft}>
             Left
           </Button>
@@ -69,18 +71,20 @@ const SimulController = ({ clickedChuckInfo, setRotationAngle }) => {
           </Button>
         </div>
         <div className="w-[80%] flex gap-3 items-center">
-          <div className="grow font-bold text-lg">length?</div>
-          <div className="font-semibold">{chuckPositionsList.length}</div>
+          <div className="grow font-bold text-xl">length?</div>
+          <div className="font-semibold text-lg">
+            {chuckPositionsList.length}
+          </div>
           <div className="flex gap-2">
             <Button
               clickHandler={handleClickAdd}
-              className="w-[38px] text-sm h-8 pl-1 pr-1"
+              className="w-[38px] text-sm h-10 pl-1 pr-1"
             >
               + 1
             </Button>
             <Button
               clickHandler={handleClickDelete}
-              className="w-[38px] text-sm h-8 pl-1 pr-1"
+              className="w-[38px] text-sm h-10 pl-1 pr-1"
             >
               - 1
             </Button>

--- a/src/pages/Modal/InitialSettingModal.jsx
+++ b/src/pages/Modal/InitialSettingModal.jsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import Button from "../../components/Button";
 import Modal from "../../components/Modal";
 import useChuckStore from "../../store/chuckStore";
@@ -9,17 +8,13 @@ const InitialSettingModal = () => {
   const setChuckPositionsList = useChuckStore(
     (state) => state.setChuckPositionsList
   );
-  const [inputValue, setInputValue] = useState(25);
-
-  const handleChangedValue = (event) => {
-    setInputValue(event.target.value);
-  };
 
   const handleClickStartButton = () => {
     const initialPositionArray = [];
+    const initialValue = 20;
     let positionX = 0;
 
-    while (initialPositionArray.length < inputValue) {
+    while (initialPositionArray.length < initialValue) {
       const positionY = initialPositionArray.length % 2 === 0 ? 0 : 2.5;
       const positionArray = [positionX, positionY, 0];
       initialPositionArray.push(positionArray);
@@ -32,21 +27,13 @@ const InitialSettingModal = () => {
 
   return (
     <Modal drection="horizontal" modalTitle="Initial Setting">
-      <form className="mt-[5%] flex flex-col gap-5 justify-center items-center">
-        <input
-          type="range"
-          name="initialInput"
-          id="initialInput"
-          min={2}
-          max={50}
-          value={inputValue}
-          onChange={handleChangedValue}
-          className="w-[80%] h-10 text-black rounded-md"
-        />
-        <div className="text-lg font-bold">{inputValue}</div>
+      <form className="mt-[15%] flex flex-col gap-5 justify-center items-center">
+        <div className="font-bold text-lg">
+          원하는 삼각기둥을 클릭 후 회전시켜 보세요!
+        </div>
         <Button
           clickHandler={handleClickStartButton}
-          className="w-[80%] text-lg pl-7 pr-7 pt-2 pb-2"
+          className="w-[80%] mt-[10%] text-lg pl-7 pr-7 pt-2 pb-2"
         >
           Start Simulation
         </Button>


### PR DESCRIPTION
# 작업 내용
**initialSetting modal**
- 시뮬레이션 시작 전 초기에 척척이 길이를 셋팅할 수 있는 기능을 제거했습니다.
- 그에 맞게 UI를 변경했습니다: 안내 메시지 출력
- Start 버튼을 누르면 자동으로 초기 척척이의 길이를 20개로 설정합니다.

**SimulController**
- 컨트롤러 내부 UI를 살짝 수정했습니다.
  - 버튼 크기, 버튼 내부 글씨 크기, 버튼 간의 간격 등

## initialSetting modal
### 이전 UI 화면
<img width="513" alt="스크린샷 2024-11-16 오후 1 58 01" src="https://github.com/user-attachments/assets/ffab7107-5cd7-48e0-8073-e4e3b73de3c2">

### 현재 UI 화면
<img width="511" alt="스크린샷 2024-11-16 오후 1 56 22" src="https://github.com/user-attachments/assets/82be3a9f-2946-43e7-81a8-38fe20ae2f35">

## SimulController
### 이전 UI 화면
<img width="266" alt="스크린샷 2024-11-16 오후 2 00 33" src="https://github.com/user-attachments/assets/150280ec-ac6e-4b22-a209-596dd855e353">

- reset 버튼의 색상이 다른 이유는 `hover` 돼 있기 때문입니다.

### 현재 UI 화면
<img width="245" alt="스크린샷 2024-11-16 오후 2 01 06" src="https://github.com/user-attachments/assets/b0aed45a-6d30-4496-b720-bbda54e792e4">


# 참고 사항
- 안내 문구는 이후 이미지와 함께 시뮬레이션 진행 방식을 추가할 예정입니다.
- 제가 변경한 내용 외에도 수정되었으면 하는 UI가 있다면 남겨 주세요.

# 리뷰 반영 내용

리뷰 내용 반영 후 수정 내용 발생시 이 부분에 작성해 주세요.
