### PR TITLE
Fix(TutorialController): essentialClickButton 값 받아오지 못 하는 버그 수정

### DIFF
--- a/src/components/TutorialController.jsx
+++ b/src/components/TutorialController.jsx
@@ -2,7 +2,7 @@ import * as CONSTANTS from "../constants/constants";
 import Button from "./Button";
 
 const TutorialController = ({
-  clickRequestButton,
+  essentialClickButton,
   isCompletedIndex,
   isCompletedButton,
   setRotationAngle,
@@ -30,7 +30,8 @@ const TutorialController = ({
           className="h-10 p-1"
           clickHandler={handleClickLeft}
           disabled={
-            (!isCompletedIndex || clickRequestButton === "right") && "disabled"
+            (!isCompletedIndex || essentialClickButton === "right") &&
+            "disabled"
           }
         >
           Left
@@ -39,7 +40,7 @@ const TutorialController = ({
           className="h-10 p-1"
           clickHandler={handleClickRight}
           disabled={
-            (!isCompletedIndex || clickRequestButton === "left") && "disabled"
+            (!isCompletedIndex || essentialClickButton === "left") && "disabled"
           }
         >
           Right


### PR DESCRIPTION
# 작업 내용
- `TutorialController`의 props를 수정해 essentialClickButton 값을 받아오지 못 하는 오류를 수정했습니다.

# 참고 사항
다른 내용은 이전 튜토리얼 로직과 동일합니다.

# 리뷰 반영 내용

리뷰 내용 반영 후 수정 내용 발생시 이 부분에 작성해 주세요.
