### PR TITLE
Feature/modification modal: 튜토리얼과 시뮬레이터 시작 모달 닫힘 버튼 제거

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -4,7 +4,7 @@ import shareImage from "../asset/share-svgrepo-com.svg";
 import ShareUrlModal from "../pages/Modal/ShareUrlModal";
 import useChuckStore from "../store/chuckStore";
 
-const Header = () => {
+const Header = ({ isTutorial }) => {
   const { chuckPositionsList, setEncodedPositionsData } = useChuckStore();
   const [isOpenedShare, setIsOpenedShare] = useState(false);
 
@@ -32,9 +32,11 @@ const Header = () => {
         >
           Chuck-Chuck! Simulator
         </Link>
-        <button className="p-1" onClick={handleClickShare}>
-          <img className="w-8" src={shareImage} alt="share link" />
-        </button>
+        {!isTutorial && (
+          <button className="p-1" onClick={handleClickShare}>
+            <img className="w-8" src={shareImage} alt="share link" />
+          </button>
+        )}
       </header>
     </>
   );

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -1,17 +1,13 @@
-import useStore from "../store/pageStore";
 import Button from "./Button";
 
 const Modal = ({ drection, title, className, setIsOpened, children }) => {
-  const setIsOpenedSimulatorModal = useStore(
-    (state) => state.setIsOpenedSimulatorModal
-  );
   const modalDrection = {
     horizontal: "w-[500px] h-[300px]",
     vertical: "w-[400px] h-[500px]",
   };
 
   const handleClickClose = () => {
-    return setIsOpened ? setIsOpened(false) : setIsOpenedSimulatorModal(false);
+    return setIsOpened(false);
   };
 
   return (
@@ -21,9 +17,11 @@ const Modal = ({ drection, title, className, setIsOpened, children }) => {
       >
         <div className="flex justify-between items-center mb-4">
           <h2 className="text-2xl font-semibold">{title}</h2>
-          <Button clickHandler={handleClickClose} className="border-2 w-8">
-            X
-          </Button>
+          {setIsOpened ? (
+            <Button clickHandler={handleClickClose} className="border-2 w-8">
+              X
+            </Button>
+          ) : null}
         </div>
         {children}
       </div>

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -11,9 +11,9 @@ const Modal = ({ drection, title, className, setIsOpened, children }) => {
   };
 
   return (
-    <div className="fixed flex items-center w-[100vw] h-[100vh] bg-black bg-opacity-25 z-20">
+    <div className="fixed flex items-center w-[100%] h-[100vh] bg-black bg-opacity-25 z-20">
       <div
-        className={`${modalDrection[drection]} ${drection === "horizontal" && "top-1/3 left-1/3"} ${drection === "vertical" && "top-5.5 left-1/3"} ${className} fixed text-white flex flex-col bg-gray-700 rounded-xl border-gray-400 border-4 p-4 z-20`}
+        className={`${modalDrection[drection]} ${drection === "horizontal" && "top-1/3 left-[33%]"} ${drection === "vertical" && "top-5.5 left-[35%]"} ${className} fixed text-white flex flex-col bg-gray-700 rounded-xl border-gray-400 border-4 p-4 z-20`}
       >
         <div className="flex justify-between items-center mb-4">
           <h2 className="text-2xl font-semibold">{title}</h2>

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -11,9 +11,9 @@ const Modal = ({ drection, title, className, setIsOpened, children }) => {
   };
 
   return (
-    <div className="fixed flex items-center w-[100%] h-[100vh] bg-black bg-opacity-25 z-20">
+    <div className="fixed flex items-center w-[100vw] h-[100vh] bg-black bg-opacity-25 z-20">
       <div
-        className={`${modalDrection[drection]} ${className} fixed top-[30%] left-[30%] text-white flex flex-col bg-gray-700 rounded-xl border-gray-400 border-4 p-4 z-20`}
+        className={`${modalDrection[drection]} ${drection === "horizontal" && "top-1/3 left-1/3"} ${drection === "vertical" && "top-5.5 left-1/3"} ${className} fixed text-white flex flex-col bg-gray-700 rounded-xl border-gray-400 border-4 p-4 z-20`}
       >
         <div className="flex justify-between items-center mb-4">
           <h2 className="text-2xl font-semibold">{title}</h2>

--- a/src/components/SimulController.jsx
+++ b/src/components/SimulController.jsx
@@ -60,6 +60,7 @@ const SimulController = ({
         return { position, quaternion };
       }
     );
+
     setChuckPositionsList(initialStateArray);
   };
 
@@ -69,7 +70,7 @@ const SimulController = ({
         <Modal
           drection="horizontalr"
           title="Select Chuck!"
-          className="w-[300px] h-[250px] top-[35%] left-[40%]"
+          className="w-[300px] h-[250px] top-[37%] left-[40%]"
           setIsOpened={setIsOpenedSelected}
         >
           <div className="h-[70%] flex justify-center items-center">

--- a/src/pages/Modal/StartTutorialModal.jsx
+++ b/src/pages/Modal/StartTutorialModal.jsx
@@ -34,12 +34,7 @@ const StartTutorialModal = () => {
   };
 
   return (
-    <Modal
-      drection="vertical"
-      title="Start Tutorial"
-      setIsOpened={setIsOpenedTutorialModal}
-      className="top-[15%] left-[35%]"
-    >
+    <Modal drection="vertical" title="Start Tutorial">
       <div className="flex w-[90%] h-[100vh] flex-col justify-center items-center ml-2 gap-3">
         <h2 className="text-center text-2xl font-bold">강아지 만들기</h2>
         <img className="m-7 w-24" src={tempChuckImage} alt="chuckimage" />

--- a/src/pages/Simulator.jsx
+++ b/src/pages/Simulator.jsx
@@ -75,7 +75,7 @@ const Simulator = () => {
   }, [clickedChuckInfo]);
 
   return (
-    <div className="text-white">
+    <div className="text-white w-screen h-screen">
       {isOpenedSimulatorModal && <StartSimulatorModal />}
       <Header />
       <main className="w-[100%] h-[100vh]">

--- a/src/pages/Tutorial.jsx
+++ b/src/pages/Tutorial.jsx
@@ -32,7 +32,7 @@ const Tutorial = () => {
   };
 
   return (
-    <div className="text-white">
+    <div className="text-white w-screen h-screen">
       {isOpenedTutorialModal && <StartTutorialModal />}
       {isCompletedTutorial && (
         <Modal

--- a/src/pages/Tutorial.jsx
+++ b/src/pages/Tutorial.jsx
@@ -48,7 +48,7 @@ const Tutorial = () => {
           </Button>
         </Modal>
       )}
-      <Header />
+      <Header isTutorial={true} />
       <main className="w-[100%] h-[100vh]">
         <Canvas
           camera={{


### PR DESCRIPTION
# 작업 내용
- 튜토리얼과 시뮬레이터를 시작할 때 뜨는 모달의 'X' 버튼을 누르면 척척이가 생기지 않는 문제가 있었습니다.
   - 이 문제를 해결하기 위해 튜토리얼과 시뮬레이터를 시작할 때 뜨는 모달에는 "X" 버튼을 제거하였습니다.
- 모든 모달이 화면 중앙에 위치할 수 있도록 조정했습니다. (모든 화면에서 완벽히 중앙이지 않을 수 있습니다.)
  - 다만 완벽하게 모든 화면 상에서 중앙으로 정렬시킬 수 있는 방법은 찾지 못 했습니다.
  - 또한 반응형은 아직 불가능합니다.
- 추가로 튜토리얼 창에서 헤더에 공유 버튼을 비활성화(화면 상에서도 제거) 했습니다.
  - 튜토리얼 진행 상황을 공유할 일은 없을 것이라 예상해 제거하였습니다.


## 실제 구현 화면
### 시뮬레이터 시작 모달
![스크린샷 2024-12-26 오전 1 25 54](https://github.com/user-attachments/assets/b1075b36-be29-44b2-96f2-299317727757)
### 튜토리얼 시작 모달
![스크린샷 2024-12-26 오전 1 30 15](https://github.com/user-attachments/assets/f1efa2db-2dee-433c-aa51-4540c4b43688)
### 모달 중앙 정렬
<img width="1509" alt="스크린샷 2024-12-26 오전 1 45 57" src="https://github.com/user-attachments/assets/d97b2cc4-13c3-40c7-b84f-a707f0398b6b" />
<img width="1508" alt="스크린샷 2024-12-26 오전 1 49 35" src="https://github.com/user-attachments/assets/b90d97e7-d92d-40a1-b7a8-211f55cd3dd7" />

### 튜토리얼 헤더에서 공유 버튼 제거
![스크린샷 2024-12-26 오전 1 28 47](https://github.com/user-attachments/assets/d5ce5b3a-4260-4e45-96b8-8afffe27c948)

# 참고 사항
추가가 필요한 사항은 없습니다.

# 리뷰 반영 내용

리뷰 내용 반영 후 수정 내용 발생시 이 부분에 작성해 주세요.
